### PR TITLE
Add timeout for Teams notification

### DIFF
--- a/aws/terraform/lambda.tf
+++ b/aws/terraform/lambda.tf
@@ -85,6 +85,7 @@ module "teams-notification" {
   function_name = "${var.prefix}-teams-notification"
   handler       = "sns_to_teams.lambda_handler"
   runtime       = "python${var.python_version}"
+  timeout       = 15 # Set a short timeout for notifications
   publish       = true
 
   source_path = "../src/lambda/notifications"


### PR DESCRIPTION
The default timeout was 3s, which can lead to duplicate messages if the Teams Lambda takes a bit too long to post the message.