### PR TITLE
(Re)set maximum memory for DOCX Lambda

### DIFF
--- a/aws/terraform/lambda.tf
+++ b/aws/terraform/lambda.tf
@@ -245,6 +245,7 @@ module "docx" {
   function_name  = "${var.prefix}-${var.lambda_docx}"
   description    = "Postprocessing for transcribe jobs"
   timeout        = 900
+  memory_size    = 2048
   publish        = true
   create_package = false
 


### PR DESCRIPTION
Restoring the maximum_memory value for the DOCX Lambda, which was lost during the conversion to step function.