### PR TITLE
51: Handle null speaker_labels

### DIFF
--- a/aws/src/lambda/docx/transcribe_to_docx.py
+++ b/aws/src/lambda/docx/transcribe_to_docx.py
@@ -353,7 +353,7 @@ def write(data, speech_segments, job_info, output_file):
         dur_text = str(int(global_audio_duration / 60)) + "m " + str(round(global_audio_duration % 60, 2)) + "s"
         job_data.append({"name": "Audio Duration", "value": dur_text})
     # We can infer diarization mode from the JSON results data structure
-    if "speaker_labels" in data["results"]:
+    if "speaker_labels" in data["results"] and data["results"]["speaker_labels"] is not None:
         job_data.append({"name": "Audio Identification", "value": "Speaker-separated"})
     elif "channel_labels" in data["results"]:
         job_data.append({"name": "Audio Identification", "value": "Channel-separated"})
@@ -995,7 +995,7 @@ def generate_document():
     start = perf_counter()
     if "channel_labels" in json_data["results"]:
         speech_segments = create_turn_by_turn_segments(json_data, isChannelMode = True)
-    elif "speaker_labels" in json_data["results"]:
+    elif "speaker_labels" in json_data["results"] and json_data["results"]["speaker_labels"] is not None:
         speech_segments = create_turn_by_turn_segments(json_data, isSpeakerMode = True)
     elif "audio_segments" in json_data["results"]:
         speech_segments = create_turn_by_turn_segments(json_data, isAudioSegmentsMode = True)


### PR DESCRIPTION
The problem with the sample file in question is that it has no audio_segments. And oddly enough it has both (a null) speaker_labels and empty audio_segments. The latter we handle, the former it crashes on. So the following will be what it outputs (after this PR):

<img width="664" height="188" alt="Screenshot 2025-07-22 at 12 37 49" src="https://github.com/user-attachments/assets/f2950916-cbff-4a58-985c-ae079744544b" />

It looks like the PR that copilot (https://github.com/indiana-university/automated-transcription-service/pull/52) came up with also produces the above docx so I'm OK with that too. Although if we go that route I'd suggest we remove the print statements: It just becomes normal operation then that an empty file generates an empty docx. Although I suppose given how it's written it does a try/catch for any failure, not just this specific scenario. I suppose it could be that it's not an empty file but fails for some other reason...

I'm OK either way, it's a difficult to foresee what other problems we might hit in future.