### PR TITLE
Update python_version Terraform variable

### DIFF
--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -85,7 +85,7 @@ variable "slack_notification" {
 variable "python_version" {
   description = "Python version to use for the Lambda functions. Supported versions: 3.12 or later"
   type        = string
-  default     = "3.12"
+  default     = "3.11"
 }
 
 variable "document_title" {


### PR DESCRIPTION
This update fixes a bug that was introduced in #57.
- Updated `python_version` variable in Terraform to align with distroless container version: 3.11,