### PR TITLE
Refactor step function and tag ATS jobs in Transcribe

### DIFF
--- a/aws/src/lambda/docx/Dockerfile
+++ b/aws/src/lambda/docx/Dockerfile
@@ -1,5 +1,5 @@
 # Python version
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.13
 
 # Define custom function directory
 ARG FUNCTION_DIR="/function"
@@ -24,21 +24,17 @@ RUN  pip install -r requirements.txt --target ${FUNCTION_DIR}
 # Change ownership of the function directory to the non-root user
 RUN chown -R appuser:appuser ${FUNCTION_DIR}
 
-# Use a distroless Python image to reduce the final image size
-FROM gcr.io/distroless/python3:nonroot
+# Use slim Python image to minimize size and attack surface
+FROM python:${PYTHON_VERSION}-slim
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 
-# Set working directory to function root directory
+# Set working directory
 WORKDIR ${FUNCTION_DIR}
 
-# Copy in the built dependencies with proper ownership
-COPY --from=build-image --chown=nonroot:nonroot ${FUNCTION_DIR} ${FUNCTION_DIR}
+# Copy in the built dependencies from build stage
+COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
-# Switch to non-root user
-USER nonroot
-
-# Set runtime interface client as default command for the container runtime
-#CMD [ "-m", "awslambdaric" ]
-ENTRYPOINT [ "/usr/bin/python3", "-m", "awslambdaric" ]
+#Set the entry point for the Lambda function
+ENTRYPOINT ["/usr/local/bin/python", "-m", "awslambdaric"]

--- a/aws/src/lambda/docx/Dockerfile
+++ b/aws/src/lambda/docx/Dockerfile
@@ -1,5 +1,5 @@
-# Python version
-ARG PYTHON_VERSION=3.13
+# Python version passed via build_args in lambda.tf
+ARG PYTHON_VERSION
 
 # Define custom function directory
 ARG FUNCTION_DIR="/function"
@@ -8,9 +8,6 @@ FROM python:${PYTHON_VERSION} AS build-image
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
-
-# Create a non-root user for building
-RUN groupadd -r appuser && useradd -r -g appuser appuser
 
 # Copy function code
 RUN  mkdir -p ${FUNCTION_DIR}
@@ -21,20 +18,23 @@ COPY requirements.txt  .
 RUN  pip install --target ${FUNCTION_DIR} awslambdaric
 RUN  pip install -r requirements.txt --target ${FUNCTION_DIR}
 
-# Change ownership of the function directory to the non-root user
-RUN chown -R appuser:appuser ${FUNCTION_DIR}
-
 # Use slim Python image to minimize size and attack surface
 FROM python:${PYTHON_VERSION}-slim
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 
+# Create a non-root user
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
 # Set working directory
 WORKDIR ${FUNCTION_DIR}
 
 # Copy in the built dependencies from build stage
-COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
+COPY --from=build-image --chown=appuser:appuser ${FUNCTION_DIR} ${FUNCTION_DIR}
 
-#Set the entry point for the Lambda function
+# Run as non-root user
+USER appuser
+
+# Set the entry point for the Lambda function
 ENTRYPOINT ["/usr/local/bin/python", "-m", "awslambdaric"]

--- a/aws/src/lambda/docx/requirements.txt
+++ b/aws/src/lambda/docx/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.40.20
 python-docx==1.2.0
-lxml>=4.9.0
+lxml==4.9.4

--- a/aws/src/lambda/docx/requirements.txt
+++ b/aws/src/lambda/docx/requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.40.20
 python-docx==1.2.0
+lxml>=4.9.0

--- a/aws/src/lambda/transcribe/audio_to_transcribe.py
+++ b/aws/src/lambda/transcribe/audio_to_transcribe.py
@@ -47,7 +47,13 @@ def lambda_handler(event, context):
                     'MediaFileUri': s3Path
                 },
                 OutputBucketName = s3bucketOutput,
-                OutputKey = today + "/"
+                OutputKey = today + "/",
+                Tags=[
+                {
+                    'Key': 'Source',
+                    'Value': 'ATS'
+                }
+            ]
             )
             print(response)
         except Exception as e:

--- a/aws/src/lambda/transcribe/audio_to_transcribe.py
+++ b/aws/src/lambda/transcribe/audio_to_transcribe.py
@@ -22,6 +22,7 @@ def lambda_handler(event, context):
     print("audio_to_transcribe.lambda_handler started")
 
     s3bucketOutput = os.environ["BUCKET"]
+    tag = os.environ.get("TAG", "ats")
     batch_failures = []
     for record in event["Records"]:
         event_message = json.loads(record["body"])
@@ -51,7 +52,7 @@ def lambda_handler(event, context):
                 Tags=[
                 {
                     'Key': 'Source',
-                    'Value': 'ATS'
+                    'Value': tag
                 }
             ]
             )

--- a/aws/terraform/lambda.tf
+++ b/aws/terraform/lambda.tf
@@ -32,6 +32,7 @@ module "transcribe" {
   environment_variables = {
     LOG_LEVEL = "INFO"
     BUCKET    = aws_s3_bucket.download.id
+    TAG       = var.prefix
   }
 
   attach_policy_json = true
@@ -47,6 +48,7 @@ module "transcribe" {
                 "s3:GetObject",
                 "s3:ListBucket",
                 "transcribe:GetTranscriptionJob",
+                "transcribe:TagResource",
                 "sqs:ReceiveMessage",
                 "sqs:DeleteMessage",
                 "sqs:GetQueueAttributes"

--- a/aws/terraform/lambda.tf
+++ b/aws/terraform/lambda.tf
@@ -47,8 +47,6 @@ module "transcribe" {
                 "s3:PutObject",
                 "s3:GetObject",
                 "s3:ListBucket",
-                "transcribe:GetTranscriptionJob",
-                "transcribe:TagResource",
                 "sqs:ReceiveMessage",
                 "sqs:DeleteMessage",
                 "sqs:GetQueueAttributes"
@@ -65,9 +63,11 @@ module "transcribe" {
             "Sid": "VisualEditor2",
             "Effect": "Allow",
             "Action": [
+                "transcribe:GetTranscriptionJob",
+                "transcribe:TagResource",
                 "transcribe:StartTranscriptionJob"
             ],
-            "Resource": "*"
+            "Resource": "arn:aws:transcribe:${var.region}:${data.aws_caller_identity.this.account_id}:transcription-job/*"
         }
     ]
   }

--- a/aws/terraform/stepfunction.tf
+++ b/aws/terraform/stepfunction.tf
@@ -31,16 +31,14 @@ module "step_function" {
       },
       "AssignTags": {
         "Type": "Pass",
-        "Assign": {
-          "tags.$": "$.transcribe.TranscriptionJob.Tags"
-        },
+        "InputPath": "$.transcribe.TranscriptionJob.Tags",
+        "ResultPath": "$.tags",
         "Next": "Tagged?"
       },
       "AssignNoTags": {
         "Type": "Pass",
-        "Assign": {
-          "tags": []
-        },
+        "Result": [],
+        "ResultPath": "$.tags",
         "Next": "Tagged?"
       },
       "Tagged?": {
@@ -49,11 +47,11 @@ module "step_function" {
           {
             "And": [
               {
-                "Variable": "$tags[0].Value",
+                "Variable": "$.tags[0].Value",
                 "IsPresent": true
               },
               {
-                "Variable": "$tags[0].Value",
+                "Variable": "$.tags[0].Value",
                 "StringEquals": "${var.prefix}"
               }
             ],

--- a/aws/terraform/stepfunction.tf
+++ b/aws/terraform/stepfunction.tf
@@ -7,8 +7,35 @@ module "step_function" {
   definition = <<EOF
   {
     "Comment": "Step function to perform post-processing on Transcriptions.",
-    "StartAt": "Transcribed?",
+    "StartAt": "GetTranscriptionJob",
     "States": {
+      "GetTranscriptionJob": {
+        "Type": "Task",
+        "Parameters": {
+          "TranscriptionJobName.$": "$.detail.TranscriptionJobName"
+        },
+        "Resource": "arn:aws:states:::aws-sdk:transcribe:getTranscriptionJob",
+        "Next": "Tagged?",
+        "ResultPath": null,
+        "Assign": {
+          "tags.$": "$.TranscriptionJob.Tags"
+        }
+      },
+      "Tagged?": {
+        "Type": "Choice",
+        "Choices": [
+          {
+            "Next": "Transcribed?",
+            "Variable": "$tags[0].Value",
+            "StringEquals": "${var.prefix}"
+          }
+        ],
+        "Default": "Untagged"
+      },
+      "Untagged": {
+        "Type": "Pass",
+        "End": true
+      },
       "Transcribed?": {
         "Comment": "Check to see if Transcribe job completed.",
         "Type": "Choice",

--- a/aws/terraform/stepfunction.tf
+++ b/aws/terraform/stepfunction.tf
@@ -15,19 +15,49 @@ module "step_function" {
           "TranscriptionJobName.$": "$.detail.TranscriptionJobName"
         },
         "Resource": "arn:aws:states:::aws-sdk:transcribe:getTranscriptionJob",
-        "Next": "Tagged?",
-        "ResultPath": null,
+        "Next": "HasTags?",
+        "ResultPath": "$.transcribe"
+      },
+      "HasTags?": {
+        "Type": "Choice",
+        "Choices": [
+          {
+            "Variable": "$.transcribe.TranscriptionJob.Tags",
+            "IsPresent": true,
+            "Next": "AssignTags"
+          }
+        ],
+        "Default": "AssignNoTags"
+      },
+      "AssignTags": {
+        "Type": "Pass",
         "Assign": {
-          "tags.$": "$.TranscriptionJob.Tags"
-        }
+          "tags.$": "$.transcribe.TranscriptionJob.Tags"
+        },
+        "Next": "Tagged?"
+      },
+      "AssignNoTags": {
+        "Type": "Pass",
+        "Assign": {
+          "tags": []
+        },
+        "Next": "Tagged?"
       },
       "Tagged?": {
         "Type": "Choice",
         "Choices": [
           {
-            "Next": "Transcribed?",
-            "Variable": "$tags[0].Value",
-            "StringEquals": "${var.prefix}"
+            "And": [
+              {
+                "Variable": "$tags[0].Value",
+                "IsPresent": true
+              },
+              {
+                "Variable": "$tags[0].Value",
+                "StringEquals": "${var.prefix}"
+              }
+            ],
+            "Next": "Transcribed?"
           }
         ],
         "Default": "Untagged"
@@ -166,4 +196,21 @@ module "step_function" {
   tags = {
     Project = "ATS"
   }
+}
+
+resource "aws_iam_role_policy" "transcribe" {
+  name   = "${var.prefix}-step-function-transcribe"
+  role   = module.step_function.role_name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "transcribe:GetTranscriptionJob"
+        ]
+        Resource = "arn:aws:transcribe:${var.region}:${data.aws_caller_identity.this.account_id}:transcription-job/*"
+      }
+    ]
+  })
 }

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -85,7 +85,7 @@ variable "slack_notification" {
 variable "python_version" {
   description = "Python version to use for the Lambda functions. Supported versions: 3.12 or later"
   type        = string
-  default     = "3.11"
+  default     = "3.13"
 }
 
 variable "document_title" {


### PR DESCRIPTION
This pull request introduces several improvements and changes to the AWS Lambda and Step Function infrastructure, primarily to support tagging of transcription jobs to avoid errors when Transcribe jobs are run manually and then trigger the step function.

The main changes include updating the Lambda Dockerfile base image, adding tagging support to transcription jobs, modifying IAM permissions, and enhancing the Step Function logic to handle tags.

Along the way, it also became necessary to undo the prior move to a distroless container. Debian no longer includes Python by default, so we will have to revisit this in a later issue.

**Lambda Dockerfile and Dependency Updates:**

- Updated the `aws/src/lambda/docx/Dockerfile` to use Python 3.13 and switched from a distroless to a slim Python base image for better compatibility and maintainability. The entrypoint was also updated to match the new image. [[1]](diffhunk://#diff-62a1cdeca7c3e8aea08ec12c5cc286c382307df3b10375754dca93333f5402f4L2-R2) [[2]](diffhunk://#diff-62a1cdeca7c3e8aea08ec12c5cc286c382307df3b10375754dca93333f5402f4L27-R40)
- Added `lxml` as a dependency in `requirements.txt` for improved XML handling in the docx Lambda.

**Transcribe Lambda Tagging Support:**

- Modified `audio_to_transcribe.py` to read a `TAG` environment variable and attach it as a tag to each transcription job, allowing downstream processes to identify jobs by source. [[1]](diffhunk://#diff-253afa70e33cd22fa4a4e2558867c6934c6b04204fe33c6cb28936aaecba86a7R25) [[2]](diffhunk://#diff-253afa70e33cd22fa4a4e2558867c6934c6b04204fe33c6cb28936aaecba86a7L50-R57)
- Updated Terraform configuration to inject the `TAG` environment variable into the Lambda from the `prefix` variable.

**IAM and Security Enhancements:**

- Adjusted IAM permissions in Terraform to scope `transcribe:GetTranscriptionJob` and related actions to only the relevant transcription jobs, and added permission for `transcribe:TagResource`. [[1]](diffhunk://#diff-fd37921a705376ac087f5c6461c7a8dc4826b392ddfdde3709fcbc5d44f49162L49) [[2]](diffhunk://#diff-fd37921a705376ac087f5c6461c7a8dc4826b392ddfdde3709fcbc5d44f49162R66-R70)
- Added a dedicated IAM role policy for the Step Function to allow it to call `transcribe:GetTranscriptionJob` on the correct resources.

**Step Function Logic Improvements:**

- Refactored the Step Function definition to:
  - Start by fetching the transcription job and its tags.
  - Branch logic based on the presence and value of tags, only proceeding if the tag matches the expected prefix.
  - Cleanly handle untagged or mismatched jobs.

These changes collectively improve traceability, security, and robustness of the transcription workflow.