### PR TITLE
feat 20: MS connectors -> Power Automate

### DIFF
--- a/aws/src/lambda/notifications/teams/sns_to_teams.py
+++ b/aws/src/lambda/notifications/teams/sns_to_teams.py
@@ -39,8 +39,35 @@ def lambda_handler(event, context):
 
     job_name = body.get("job", "Unknown Job")
     s3uri = body.get("s3uri", "No S3 URI provided")
-    teams_message = f"Job Name:<br><pre>{job_name}</pre><br>Transcript available at:<br><pre>{s3uri}</pre>"
-    message = {"summary": title, "sections": [{"activityTitle": title, "activitySubtitle": teams_message}]}
+    message = {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "contentUrl": None,
+                "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "size": "Medium",
+                            "weight": "Bolder",
+                            "text": title,
+                        },
+                        {
+                            "type": "FactSet",
+                            "facts": [
+                                {"title": "Job Name", "value": job_name},
+                                {"title": "Transcript S3 URI", "value": s3uri},
+                            ],
+                        },
+                    ],
+                },
+            }
+        ],
+    }
     request_data = json.dumps(message).encode("utf-8")
     req = Request(url=webhook, headers={"Content-Type": "application/json"}, data=request_data, method='POST')
 

--- a/aws/src/lambda/notifications/teams/sns_to_teams.py
+++ b/aws/src/lambda/notifications/teams/sns_to_teams.py
@@ -39,6 +39,11 @@ def lambda_handler(event, context):
 
     job_name = body.get("job", "Unknown Job")
     s3uri = body.get("s3uri", "No S3 URI provided")
+    title_lower = title.lower()
+    if "fail" in title_lower or "stop" in title_lower or "error" in title_lower:
+        header_style = "attention"
+    else:
+        header_style = "good"
     message = {
         "type": "message",
         "attachments": [
@@ -49,12 +54,21 @@ def lambda_handler(event, context):
                     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
                     "type": "AdaptiveCard",
                     "version": "1.4",
+                    "msteams": {"width": "Full"},
                     "body": [
                         {
-                            "type": "TextBlock",
-                            "size": "Medium",
-                            "weight": "Bolder",
-                            "text": title,
+                            "type": "Container",
+                            "style": header_style,
+                            "bleed": True,
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "size": "Medium",
+                                    "weight": "Bolder",
+                                    "text": title,
+                                    "wrap": True,
+                                },
+                            ],
                         },
                         {
                             "type": "FactSet",


### PR DESCRIPTION
@alan-walsh 

This PR updates our template for MS Team integration. Furthermore Claude provides the below guide in updating our local channel. Note my followup question where we can also play with the template design and update it if we wish.

I checked our local channel, I don't have a Workflows tab but I have a Power Automate tab. However, it doesn't load when I click on it. I can see that we are listed as Members in the Channel while Emily is the Owner. Maybe she has to make the update? I'm also not familiar with Teams other then basic usage. Lets discuss on Monday.

-----------------------------------

⏺ Good. Here's a summary of what was done and what you still need to do:                  
                                                                                        
  Code Change                                                                             
                                                                                          
  The payload in aws/src/lambda/notifications/teams/sns_to_teams.py was updated from the  
  legacy Office 365 Connector MessageCard format (summary/sections/activityTitle) to the  
  Adaptive Card format required by Power Automate Workflows. The new payload uses the     
  standard type: "message" wrapper with an attachments array containing an Adaptive Card
  v1.4.

  The old connector format stops working April 30, 2026 — less than a month away.         
  
  What You Need to Do in Your Teams Channel                                               
                                                                                        
  1. Create a Workflow in the target Teams channel:                                       
    - In Teams, go to the channel where notifications should post
    - Click the ... menu on the channel > Workflows                                       
    - Select the "Post to a channel when a webhook request is received" template          
    - Name the workflow and confirm the channel                                           
    - Once created, it will give you a new webhook URL (it will look like                 
  https://<region>.logic.azure.com/workflows/...)                                         
  2. Update the webhook URL in AWS Secrets Manager:                                       
    - Replace the old outlook.office.com/webhook/... URL stored in Secrets Manager        
  (referenced by WEBHOOK_SECRET_ARN) with the new Workflows URL from step 1               
  3. Test it by triggering a transcription job and verifying the notification appears in  
  the channel.                                                                            
                                                                                        
  Note: The new Workflow is owned by the user who creates it (not the channel). For       
  production use, consider creating it under a service account so it doesn't break if   
  someone leaves the org.                                                                 
                                                                                        
✻ Cogitated for 1m 31s               

❯ Do you have a sample how the adaptive card would look like? It doesn't need to be       
exactly what we have in this project, it's fine if there is a sample online of how it     
generically looks like. Just so I know what to expect                                     
                                                                                          
⏺ The best way to see it is the official Adaptive Cards Designer from Microsoft — it's an 
  interactive tool where you can preview cards live:                                      
             
  https://adaptivecards.io/designer/                                                      
                                                                                          
  When you open it, you'll see a visual preview of an Adaptive Card right away with a     
  sample. You can also paste our payload into the editor to preview exactly what our      
  notification will look like.                                                            
                  
  Here's a minimal standalone example you could paste into the "Card Payload Editor"      
  panel:
                                                                                          
```
  {               
      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
      "type": "AdaptiveCard",
      "version": "1.4",
      "body": [                                                                           
          {
              "type": "TextBlock",                                                        
              "size": "Medium",
              "weight": "Bolder",
              "text": "ATS Transcription Complete"
          },
          {
              "type": "FactSet",                                                          
              "facts": [
                  {"title": "Job Name", "value": "my-transcription-job-123"},             
                  {"title": "Transcript S3 URI", "value":
  "s3://my-bucket/transcripts/output.json"}                                               
              ]
          }                                                                               
      ]           
  }
```

  Make sure you select "Microsoft Teams" as the Host App in the top bar of the designer — 
  the rendering varies slightly between hosts.
                                                                                          
  In general, Adaptive Cards in Teams render as a clean card with a white background, bold
   title text at the top, and the FactSet shows as a two-column label/value list (like a
  small table). It's visually similar to what the old MessageCard looked like, just       
  structured differently under the hood.
