### PR TITLE
Enable deletion protection for DynamoDB table

### DIFF
--- a/aws/terraform/dynamodb.tf
+++ b/aws/terraform/dynamodb.tf
@@ -25,6 +25,8 @@ module "dynamodb_table" {
   point_in_time_recovery_enabled = true
   server_side_encryption_enabled = true
 
+  deletion_protection_enabled = true
+
   tags = {
     Project = "ATS"
   }


### PR DESCRIPTION
This change helps prevent accidental deletion of the table, enhancing data safety.

- Enabled `deletion_protection_enabled` for the DynamoDB table in `aws/terraform/dynamodb.tf` to safeguard against accidental deletions.