### PR TITLE
64: Pass json on transcribe failure

### DIFF
--- a/aws/terraform/stepfunction.tf
+++ b/aws/terraform/stepfunction.tf
@@ -74,14 +74,29 @@ module "step_function" {
             "Next": "Create DOCX"
           }
         ],
-        "Default": "Transcribe failed notification"
+        "Default": "Build failure body"
+      },
+      "Build failure body": {
+        "Type": "Pass",
+        "Parameters": {
+          "job.$": "$.detail.TranscriptionJobName",
+          "s3uri": "N/A",
+          "subject": "Transcription job failed"
+        },
+        "ResultPath": "$.body",
+        "Next": "Transcribe failed notification"
       },
       "Transcribe failed notification": {
         "Type": "Task",
-        "Resource": "arn:aws:states:::sns:publish",
+        "Resource": "arn:aws:states:::aws-sdk:sns:publish",
         "Parameters": {
-          "Message": "Transcribe job failed. See CloudWatch logs for details.",
-          "TopicArn": "${module.sns_topic.topic_arn}"
+          "TopicArn": "${module.sns_topic.topic_arn}",
+          "Subject.$": "$.body.subject",
+          "MessageStructure": "json",
+          "Message": {
+            "default.$": "States.Format('Transcription job {} failed. See CloudWatch logs for details.', $.body.job)",
+            "lambda.$": "States.JsonToString($.body)"
+          }
         },
         "Next": "ERROR"
       },


### PR DESCRIPTION
stepfunction.tf Line 79 published a string instead of json as error message. Compare to the success scenario on Line 110. Proposed solution: Construct a json as error message.